### PR TITLE
[ADD]프로젝트 삭제 시 멤버프로젝트 엔티티 삭제

### DIFF
--- a/src/main/java/com/service/releasenote/domain/member/dao/MemberProjectRepository.java
+++ b/src/main/java/com/service/releasenote/domain/member/dao/MemberProjectRepository.java
@@ -1,0 +1,8 @@
+package com.service.releasenote.domain.member.dao;
+
+import com.service.releasenote.domain.member.model.MemberProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberProjectRepository extends JpaRepository<MemberProject, Long> {
+
+}

--- a/src/main/java/com/service/releasenote/domain/project/application/ProjectService.java
+++ b/src/main/java/com/service/releasenote/domain/project/application/ProjectService.java
@@ -1,7 +1,11 @@
 package com.service.releasenote.domain.project.application;
 
+import com.service.releasenote.domain.category.dao.CategoryRepository;
+import com.service.releasenote.domain.category.model.Category;
 import com.service.releasenote.domain.company.dao.CompanyRepository;
 import com.service.releasenote.domain.company.model.Company;
+import com.service.releasenote.domain.member.dao.MemberProjectRepository;
+import com.service.releasenote.domain.member.model.MemberProject;
 import com.service.releasenote.domain.member.model.Role;
 import com.service.releasenote.domain.project.dao.ProjectRepository;
 import com.service.releasenote.domain.project.exception.exceptions.CompanyNotFoundException;
@@ -27,6 +31,8 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final CompanyRepository companyRepository;
+    private final CategoryRepository categoryRepository;
+    private final MemberProjectRepository memberProjectRepository;
 
     @Transactional
     public CreateProjectResponseDto createProject
@@ -61,6 +67,7 @@ public class ProjectService {
 
         // member_project 테이블에서 currentMemberId와 companyId를 이용해서 role 찾기
         Role roleByMemberIdAndProjectId = projectRepository.findRoleByMemberIdAndProjectId(projectId, currentMemberId);
+//        log.info(roleByMemberIdAndProjectId.toString());    // OWNER
 
         // OWNER가 아닐 경우 예외 처리 (프로젝트를 삭제할 권한이 없습니다)
         if (!roleByMemberIdAndProjectId.equals(Role.OWNER)) {
@@ -72,6 +79,21 @@ public class ProjectService {
         // 2. 내가 속한 프로젝트 리스트에서 삭제 되어야 한다.
         // 3. member_project에서 삭제 되어야 하나?
         // 4. 프로젝트의 하위 카테고리도 (자동으로? cascade 어쩌구..) 삭제되어야 한다.
+        // 5. 프로젝트 삭제
+
+        // 3
+        List<MemberProject> memberProjectByProjectId = projectRepository.findMemberProjectByProjectId(projectId);
+        for (MemberProject memberProject : memberProjectByProjectId) {
+            memberProjectRepository.delete(memberProject);
+        }
+
+        // 4
+//        List<Category> categoryIdByProjectId = projectRepository.findCategoryByProjectId(projectId);
+//        for (Category category : categoryIdByProjectId) {
+//            categoryRepository.delete(category);
+//        }
+
+        // 프로젝트 삭제
         projectRepository.delete(project);
 
     }

--- a/src/main/java/com/service/releasenote/domain/project/dao/ProjectRepository.java
+++ b/src/main/java/com/service/releasenote/domain/project/dao/ProjectRepository.java
@@ -1,5 +1,7 @@
 package com.service.releasenote.domain.project.dao;
 
+import com.service.releasenote.domain.category.model.Category;
+import com.service.releasenote.domain.member.model.MemberProject;
 import com.service.releasenote.domain.member.model.Role;
 import com.service.releasenote.domain.project.model.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,9 +14,13 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Query(value = "SELECT p.title FROM project p WHERE p.company_id = :company_id", nativeQuery = true)
     List<String> findTitleByCompanyId(@Param("company_id")Long company_id);
 
-    List<Project> findByCompanyId(@Param("company_id")Long company_id);
-
     @Query(value = "SELECT mp.role FROM member_project mp WHERE mp.member_id = :member_id and mp.project_id = :project_id", nativeQuery = true)
     Role findRoleByMemberIdAndProjectId(@Param("project_id")Long project_id, @Param("member_id")Long member_id);
+
+//    @Query(value = "SELECT ")
+//    List<Category> findCategoryByProjectId(@Param("project_id")Long project_id);
+
+    @Query(value = "SELECT * FROM member_project mp WHERE mp.project_id = :project_id", nativeQuery = true)
+    List<MemberProject> findMemberProjectByProjectId(@Param("project_id")Long project_id);
 
 }

--- a/src/main/java/com/service/releasenote/domain/project/exception/handler/ProjectExceptionHandler.java
+++ b/src/main/java/com/service/releasenote/domain/project/exception/handler/ProjectExceptionHandler.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
-import static com.service.releasenote.domain.project.exception.response.ProjectErrorResponse.NOT_OWNER_PROJECT;
 
 @Slf4j
 @RestControllerAdvice


### PR DESCRIPTION
### PR 타이틀
+ 프로젝트 삭제 시 멤버프로젝트 엔티티 삭제 
***

### 생성 날짜
+ 230717

***
### PR 내용
+ 프로젝트 삭제 시 1)category , 2)member_project 삭제
+ project에 엮여 있는 엔티티가 2개이므로 cascade 불가
+ 와중에 category는 삭제 시 1)release, 2) detail 삭제
+ categoryRepository에서 delete 메소드가 완성되면 추후 구현 예정


