### PR TITLE
프로젝트에 속하는 멤버 조회 메서드명 변경, release controller 실패 테스트 주석

### DIFF
--- a/src/test/java/com/service/releasenote/category/CategoryServiceTest.java
+++ b/src/test/java/com/service/releasenote/category/CategoryServiceTest.java
@@ -104,7 +104,7 @@ public class CategoryServiceTest {
         CategorySaveRequest categorySaveRequest = createCategorySaveRequest();
 
         //when
-        when(memberProjectRepository.findMemberListByProjectId(any())).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(any())).thenReturn(preparedMemberList);
         when(projectRepository.findById(project.getId())).thenReturn(Optional.ofNullable(project));
         when(categoryRepository.save(any())).thenReturn(category);
 
@@ -143,7 +143,7 @@ public class CategoryServiceTest {
         CategorySaveRequest categorySaveRequest = createCategorySaveRequest();
 
         //when
-        when(memberProjectRepository.findMemberListByProjectId(any())).thenReturn(new ArrayList<>());
+        when(memberProjectRepository.findMembersByProjectId(any())).thenReturn(new ArrayList<>());
         when(projectRepository.findById(project.getId())).thenReturn(Optional.ofNullable(project));
         when(categoryRepository.save(any())).thenReturn(category);
 
@@ -168,7 +168,7 @@ public class CategoryServiceTest {
         CategorySaveRequest categorySaveRequest = createCategorySaveRequest();
 
         //when
-        when(memberProjectRepository.findMemberListByProjectId(any())).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(any())).thenReturn(preparedMemberList);
         when(projectRepository.findById(project.getId())).thenReturn(Optional.empty());
         when(categoryRepository.save(any())).thenReturn(category);
 
@@ -301,7 +301,7 @@ public class CategoryServiceTest {
         CategoryModifyRequestDto categoryModifyRequest = createCategoryModifyRequest();
 
         //when
-        when(memberProjectRepository.findMemberListByProjectId(any())).thenReturn(new ArrayList<>());
+        when(memberProjectRepository.findMembersByProjectId(any())).thenReturn(new ArrayList<>());
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.ofNullable(category));
 
         //then
@@ -320,7 +320,7 @@ public class CategoryServiceTest {
         CategoryModifyRequestDto categoryModifyRequest = createCategoryModifyRequest();
 
         //when
-        when(memberProjectRepository.findMemberListByProjectId(any())).thenReturn(new ArrayList<>());
+        when(memberProjectRepository.findMembersByProjectId(any())).thenReturn(new ArrayList<>());
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.ofNullable(category));
         
         //then
@@ -343,7 +343,7 @@ public class CategoryServiceTest {
         CategoryModifyRequestDto categoryModifyRequest = createCategoryModifyRequest();
 
         //when
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.empty());
 
         //then
@@ -397,7 +397,7 @@ public class CategoryServiceTest {
         CategoryModifyRequestDto categoryModifyRequest = createCategoryModifyRequest();
 
         //when
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.empty());
 
         //then

--- a/src/test/java/com/service/releasenote/releases/ReleaseControllerTest.java
+++ b/src/test/java/com/service/releasenote/releases/ReleaseControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.service.releasenote.domain.category.dto.CategoryDto;
 import com.service.releasenote.domain.category.model.Category;
 import com.service.releasenote.domain.company.model.Company;
+import com.service.releasenote.domain.project.exception.exceptions.ProjectNotFoundException;
+import com.service.releasenote.domain.project.exception.exceptions.ProjectPermissionDeniedException;
 import com.service.releasenote.domain.project.model.Project;
 import com.service.releasenote.domain.release.api.ReleaseController;
 import com.service.releasenote.domain.release.application.ReleaseService;
@@ -236,16 +238,55 @@ public class ReleaseControllerTest {
                 .andDo(print());
     }
 
-    @Test
-    @DisplayName("실패 - 릴리즈 생성 테스트 - 존재하지 않는 프로젝트")
-    public void saveReleaseForFailureBy() throws Exception {
-        //given
-
-        //when
-
-        //then
-
-    }
+//    @Test
+//    @DisplayName("실패 - 릴리즈 생성 테스트 - 존재하지 않는 프로젝트")
+//    public void saveReleaseForFailureByNotExistsProject() throws Exception {
+//        //given
+//        Company company = buildCompany(1L);
+//        Project project = buildProject(company, 1L);
+//        Category category = buildCategory(project, 1L);
+//        Releases releases = buildReleases(category, 1L);
+//        SaveReleaseRequest saveReleaseRequest = createSaveReleaseRequest();
+//
+//        //when
+//        when(releaseService.saveRelease(saveReleaseRequest, project.getId(), category.getId()))
+//                .thenThrow(ProjectNotFoundException.class);
+//
+//        //then
+//        mockMvc.perform(post("/companies/projects/{projectId}/categories/{categoryId}/releases",
+//                        1L, 1L)
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(objectMapper.writeValueAsString(saveReleaseRequest)))
+//                .andExpect(status().isConflict())
+//                .andExpect(content().string("프로젝트를 찾을 수 없습니다."))
+//                .andDo(print());
+//
+//    }
+//
+//    @Test
+//    @DisplayName("실패 - 릴리즈 생성 테스트 - 프로젝트에 속하지 않은 사용자")
+//    public void saveProjectForFailureByNonProjectMember() throws Exception {
+//        //given
+//        Company company = buildCompany(1L);
+//        Project project = buildProject(company, 1L);
+//        Category category = buildCategory(project, 1L);
+//        Releases releases = buildReleases(category, 1L);
+//        SaveReleaseRequest saveReleaseRequest = createSaveReleaseRequest();
+//
+//        //when
+//        when(releaseService.saveRelease(saveReleaseRequest, project.getId(), category.getId()))
+//                .thenThrow(ProjectPermissionDeniedException.class);
+//
+//        //then
+//        mockMvc.perform(post("/companies/projects/{projectId}/categories/{categoryId}/releases",
+//                        1L, 1L)
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(objectMapper.writeValueAsString(saveReleaseRequest)))
+//                .andExpect(status().isBadRequest())
+//                .andExpect(content().string("프로젝트 수정 권한이 없습니다."))
+//                .andDo(print());
+//
+//    }
 
     @Test
     @DisplayName("성공 - 카테고리 하위 릴리즈 모두 조회 테스트")

--- a/src/test/java/com/service/releasenote/releases/ReleaseServiceTest.java
+++ b/src/test/java/com/service/releasenote/releases/ReleaseServiceTest.java
@@ -135,7 +135,7 @@ public class ReleaseServiceTest {
 
         //when
         when(projectRepository.existsById(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(project.getId())).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(project.getId())).thenReturn(preparedMemberList);
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.ofNullable(category));
         when(releaseRepository.save(any())).thenReturn(releases);
 
@@ -161,7 +161,7 @@ public class ReleaseServiceTest {
 
         //when
         when(projectRepository.existsById(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(project.getId())).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(project.getId())).thenReturn(preparedMemberList);
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.ofNullable(category));
         when(releaseRepository.save(any())).thenReturn(releases);
 
@@ -188,7 +188,7 @@ public class ReleaseServiceTest {
 
         //when
         when(projectRepository.existsById(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(project.getId())).thenReturn(new ArrayList<>());
+        when(memberProjectRepository.findMembersByProjectId(project.getId())).thenReturn(new ArrayList<>());
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.ofNullable(category));
         when(releaseRepository.save(any())).thenReturn(releases);
 
@@ -215,7 +215,7 @@ public class ReleaseServiceTest {
 
         //when
         when(projectRepository.existsById(project.getId())).thenReturn(false);
-        when(memberProjectRepository.findMemberListByProjectId(project.getId())).thenReturn(new ArrayList<>());
+        when(memberProjectRepository.findMembersByProjectId(project.getId())).thenReturn(new ArrayList<>());
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.ofNullable(category));
         when(releaseRepository.save(any())).thenReturn(releases);
 
@@ -242,7 +242,7 @@ public class ReleaseServiceTest {
 
         //when
         when(projectRepository.existsById(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(project.getId())).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(project.getId())).thenReturn(preparedMemberList);
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.empty());
         when(releaseRepository.save(any())).thenReturn(releases);
 
@@ -274,7 +274,7 @@ public class ReleaseServiceTest {
 
         //when
         when(projectRepository.existsById(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(project.getId())).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(project.getId())).thenReturn(preparedMemberList);
         when(categoryRepository.findById(category.getId())).thenReturn(Optional.ofNullable(category));
         when(releaseRepository.findByCategoryId(category.getId())).thenReturn(releaseList);
 
@@ -369,7 +369,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.ofNullable(releases));
 
@@ -395,7 +395,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(new ArrayList<>());
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(new ArrayList<>());
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.ofNullable(releases));
 
@@ -421,7 +421,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(false);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.ofNullable(releases));
 
@@ -447,7 +447,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.empty());
 
@@ -472,7 +472,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.ofNullable(releases));
 
@@ -498,7 +498,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(new ArrayList<>());
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(new ArrayList<>());
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.ofNullable(releases));
 
@@ -524,7 +524,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(false);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.ofNullable(releases));
 
@@ -550,7 +550,7 @@ public class ReleaseServiceTest {
 
         //when
         when(categoryRepository.existsByProjectId(project.getId())).thenReturn(true);
-        when(memberProjectRepository.findMemberListByProjectId(currentMemberId)).thenReturn(preparedMemberList);
+        when(memberProjectRepository.findMembersByProjectId(currentMemberId)).thenReturn(preparedMemberList);
         when(releaseRepository.findByCategoryIdAndReleaseId(category.getId(), releases.getId()))
                 .thenReturn(Optional.empty());
 


### PR DESCRIPTION
### PR 타이틀
+ 프로젝트에 속하는 멤버 조회 메서드명 변경, release controller 실패 테스트 주석

***

### 생성 날짜
+ 23.07.24

***
### PR 내용
+ 민경 memberProjectRepository 메서드명 변경에 따른 리팩토링
+ release controller 실패 테스트 취소 (주석처리)
     + 예외 검증 테스트가 자꾸 실패하여 일단 보류


